### PR TITLE
Broker channel configuration and ESP8266 fix

### DIFF
--- a/tasmota/support_tasmesh.ino
+++ b/tasmota/support_tasmesh.ino
@@ -150,16 +150,16 @@ enum MESH_Role {
 };
 
 enum MESH_Packet_Type {                         // Type of packet
-  PACKET_TYPE_TIME = 0,                         // 
+  PACKET_TYPE_TIME = 0,                         //
   PACKET_TYPE_PEERLIST,                         // send all kown peers, broker is always 0
   PACKET_TYPE_COMMAND,                          // not used yet
   PACKET_TYPE_REGISTER_NODE,                    // register a node with encrypted broker-MAC, announce mqtt topic to ESP32-proxy
   PACKET_TYPE_MQTT,                             // send regular mqtt messages, single or multipackets
   PACKET_TYPE_WANTTOPIC                         // the broker has no topic for this peer/node
-}; 
+};
 
 /*********************************************************************************************\
- * 
+ *
 \*********************************************************************************************/
 #ifdef ESP32
 void MESHsendTime(){ //only from broker to nodes

--- a/tasmota/xdrv_50_tasmesh.ino
+++ b/tasmota/xdrv_50_tasmesh.ino
@@ -612,7 +612,7 @@ bool MESHCmd(void) {
 
     switch (command_code) {
       case CMND_MESH_BROKER:
-        MESH.channel = WiFi.channel(); // Broker get the channel from the router, no need to declare it with MESHCHANNEL
+        MESH.channel = WiFi.channel(); // Broker gets the channel from the router, no need to declare it with MESHCHANNEL
         MESHstartBroker();
         Response_P(S_JSON_MESH_COMMAND_NVALUE, command, MESH.channel);
         break;
@@ -662,6 +662,12 @@ bool Xdrv50(uint8_t function)
   switch (function) {
     case FUNC_PRE_INIT:
       MESHInit();                              // TODO: save state
+      break;
+    case FUNC_INIT:
+#ifdef ESP8266
+      Settings.flag4.network_wifi = 1;
+      TasmotaGlobal.global_state.wifi_down = 0;
+#endif //ESP8266
       break;
     case FUNC_EVERY_50_MSECOND:
       MESHevery50MSecond();

--- a/tasmota/xdrv_50_tasmesh.ino
+++ b/tasmota/xdrv_50_tasmesh.ino
@@ -171,7 +171,7 @@ void MESHInit(void) {
 #ifdef ESP32
 /**
  * @brief Subscribes as a proxy
- * 
+ *
  * @param topic - received from the referring node
  */
 void MESHsubscribe(char *topic){
@@ -186,7 +186,7 @@ void MESHunsubscribe(char *topic){
   MqttUnsubscribe(stopic);
 }
 
-void MESHconnectMQTT(void){ 
+void MESHconnectMQTT(void){
   for(auto &_peer : MESH.peers){
     AddLog_P(LOG_LEVEL_INFO, PSTR("MESH: reconnect topic: %s"),_peer.topic);
     if(_peer.topic[0]!=0){
@@ -196,14 +196,14 @@ void MESHconnectMQTT(void){
 }
 
 /**
- * @brief Intercepts mqtt message, that the broker (ESP32) subscribes to as a proxy for a node. 
+ * @brief Intercepts mqtt message, that the broker (ESP32) subscribes to as a proxy for a node.
  *        Is called from xdrv_02_mqtt.ino. Will send the message in the payload via ESP-NOW.
- * 
- * @param _topic 
- * @param _data 
- * @param data_len 
- * @return true 
- * @return false 
+ *
+ * @param _topic
+ * @param _data
+ * @param data_len
+ * @return true
+ * @return false
  */
 bool MESHinterceptMQTTonBroker(char* _topic, uint8_t* _data, unsigned int data_len){
   char stopic[TOPSZ];
@@ -247,12 +247,12 @@ void MESHreceiveMQTT(mesh_packet_t *_packet){
 /**
  * @brief Redirects the mqtt message on the node just before it would have been sended to 
  *        the broker via ESP-NOW
- * 
- * @param _topic 
- * @param _data 
+ *
+ * @param _topic
+ * @param _data
  * @param _retained - currently unused
- * @return true 
- * @return false 
+ * @return true
+ * @return false
  */
 bool MESHrouteMQTTtoMESH(const char* _topic, char* _data, bool _retained){
   size_t _bytesLeft = strlen(_topic)+strlen(_data)+2;
@@ -307,7 +307,7 @@ bool MESHrouteMQTTtoMESH(const char* _topic, char* _data, bool _retained){
 
 /**
  * @brief The node sends its mqtt topic to the broker
- * 
+ *
  */
 void MESHregisterNode(){
   memcpy(MESH.sendPacket.receiver,MESH.broker,6); // first 6 bytes -> MAC of broker
@@ -612,6 +612,7 @@ bool MESHCmd(void) {
 
     switch (command_code) {
       case CMND_MESH_BROKER:
+        MESH.channel = WiFi.channel(); // Broker get the channel from the router, no need to declare it with MESHCHANNEL
         MESHstartBroker();
         Response_P(S_JSON_MESH_COMMAND_NVALUE, command, MESH.channel);
         break;


### PR DESCRIPTION
## Description:
- Differently from a Node, the Broker doesn't need to set the channel since is determined by the router where it is connected. 
On Tasmota's WebUI the channel is correctly reported since is determined reading the value of `WiFi.channel()` but when enabling the Broker ` MESH.channel` default to `0` instead. 
- Sometimes an ESP8266 stay with wifi disabled on boot, even if there is no connection to the broker and the timeout based on `millis()` will not work since a new RTC is not received. To avoid it is better enable the wifi at `FUNC_INIT` (can be moved to `FUNC_PRE_INIT` if needed). After the device has received the RTC a rule based on `system#boot` (or eventually a persistent setting) will work as expected to set the meshchannel and turn on the node. 
- Also passed the files with a mild Lint to remove white spaces.

## Checklist:
  - [ ] The pull request is done against the latest dev branch
  - [ ] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR.
  - [ ] The code change is tested and works on core ESP8266 V.2.7.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.0
  - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
